### PR TITLE
Add WebSocket passthrough integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "22.x"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha \"tests/**/*.test.js\""
   },
   "repository": {
     "type": "git",
@@ -23,5 +23,9 @@
   "dependencies": {
     "winston": "^3.17.0",
     "ws": "^8.18.2"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "chai": "^4.3.10"
   }
 }

--- a/tests/passthrough.test.js
+++ b/tests/passthrough.test.js
@@ -1,0 +1,54 @@
+const { expect } = require('chai');
+const WebSocket = require('ws');
+const { spawn } = require('child_process');
+const path = require('path');
+
+// Increase test timeout because spawning processes may take time
+const PORT = 3001; // dummy TCP server port
+const WS_PORT = 8080;
+
+describe('WebSocket passthrough integration', function() {
+  this.timeout(10000);
+  let tcpServer;
+  let wsServer;
+
+  before(done => {
+    const echoPath = path.join(__dirname, 'dummyTcpEchoServer.js');
+    tcpServer = spawn('node', [echoPath, PORT]);
+    tcpServer.on('error', done);
+    // Wait a bit for TCP server to be ready
+    setTimeout(() => {
+      const serverPath = path.join(__dirname, '..', 'src', 'index.js');
+      wsServer = spawn('node', [serverPath]);
+      wsServer.on('error', done);
+      // give server time to start
+      setTimeout(done, 500);
+    }, 500);
+  });
+
+  after(done => {
+    if (wsServer) wsServer.kill();
+    if (tcpServer) tcpServer.kill();
+    setTimeout(done, 200);
+  });
+
+  it('echos data sent through /config and /data', done => {
+    const client = new WebSocket(`ws://localhost:${WS_PORT}`);
+
+    client.on('open', () => {
+      // Listen for config response first
+      client.once('message', () => {
+        // After config success, listen for echo
+        client.once('message', msg => {
+          expect(msg.toString()).to.equal('hello');
+          client.close();
+          done();
+        });
+        client.send(JSON.stringify({ path: '/data', data: 'hello' }));
+      });
+      client.send(JSON.stringify({ path: '/config', data: { targetIp: '127.0.0.1', targetPort: PORT } }));
+    });
+
+    client.on('error', done);
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha and chai as dev dependencies
- run mocha test files in `npm test` script
- implement integration test for passthrough behavior

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684675c22c148322bb07a0233df9a6ff